### PR TITLE
Make check for `on...` attributes case-insensitive

### DIFF
--- a/assets/resources/scriptlets.js
+++ b/assets/resources/scriptlets.js
@@ -3817,7 +3817,7 @@ function setAttr(
             const before = elem.getAttribute(attr);
             const after = extractValue(elem);
             if ( after === before ) { continue; }
-            if ( attr.startsWith('on') && attr in elem && after !== '' ) { continue; }
+            if ( attr.toLowerCase().startsWith('on') && attr.toLowerCase() in elem && after !== '' ) { continue; }
             elem.setAttribute(attr, after);
             safe.uboLog(logPrefix, `${attr}="${after}"`);
         }


### PR DESCRIPTION
Attribute names are case-insensitive, so a filter list could include `oNcLiCk`.

However, `'oNcLiCk' in elem` is false whereas `'onclick' in elem` is true.

Related commit:
068b625bef25b330bd9e611648ece3362dba8ab2